### PR TITLE
Sonar Scanner Refactoring

### DIFF
--- a/tekton/README.md
+++ b/tekton/README.md
@@ -311,11 +311,11 @@ spec:
   - name: sonarHostUrl
     value: https://sonarcloud.io
   - name: sonarProject
-    value: app-factory
+    value: tekton
   - name: sonarTokenSecret
     value: tkn-sonar-token
   - name: repoUrl
-    value: git@github.com:gregnrobinson/app-factory.git
+    value: git@github.com:gregnrobinson/gregrobinson-ca-k8s.git
   - name: branchName
     value: main
   workspaces:

--- a/tekton/README.md
+++ b/tekton/README.md
@@ -330,9 +330,6 @@ spec:
   - name: ssh-creds
     secret:
       secretName: tkn-ssh-credentials
-  - name: docker-config
-    secret:
-      secretName: tkn-docker-credentials
   - name: sonar-settings
     emptyDir: {}
 EOF

--- a/tekton/README.md
+++ b/tekton/README.md
@@ -283,6 +283,21 @@ EOF
 
 *Scans a given repository against a provided SonarCloud project. [SonarCloud](https://sonarcloud.io/)*
 
+Requires a secret within the task named `tkn-sonar-secret`. This is used to authenticate to SonarCloud or SonarQube.
+
+For scans with SonarCloud, create a `sonar-project.properties` file at the root of the repository that is referenced in the `repoUrl` parameter.
+
+```conf
+# sonar-project.properties
+sonar.organization=ci-testing
+sonar.projectKey=tekton
+sonar.host.url=https://sonarcloud.io
+```
+
+- **sonarHostUrl**: The SonarQube/SonarCloud instance.  
+- **sonarProject**: The project to run the scan against.  
+- **sonarTokenSecret**: The authentication token for SonarQube/SonarCloud.
+
 ```yaml
 cat <<EOF | kubectl create -f -
 apiVersion: tekton.dev/v1beta1
@@ -297,6 +312,8 @@ spec:
     value: https://sonarcloud.io
   - name: sonarProject
     value: app-factory
+  - name: sonarTokenSecret
+    value: tkn-sonar-token
   - name: repoUrl
     value: git@github.com:gregnrobinson/app-factory.git
   - name: branchName

--- a/tekton/base/pipelines/sonar.yaml
+++ b/tekton/base/pipelines/sonar.yaml
@@ -11,9 +11,6 @@ spec:
     - name: ssh-creds
       description: |
         This workspace will provide ssh credentials to the git-clone task.
-    - name: docker-config
-      description: |
-        This workspace will provide docker credentials to the docker-build-push task.
     - name: sonar-settings
   params:
   - name: repoUrl

--- a/tekton/base/pipelines/sonar.yaml
+++ b/tekton/base/pipelines/sonar.yaml
@@ -24,6 +24,8 @@ spec:
     type: string
   - name: sonarProject
     type: string
+  - name: sonarTokenSecret
+    type: string
   tasks:
     - name: fetch-repository
       taskRef:
@@ -50,6 +52,8 @@ spec:
           value: $(params.sonarHostUrl)
         - name: SONAR_PROJECT_KEY
           value: $(params.sonarProject)
+        - name: SONAR_TOKEN_SECRET
+          value: $(params.sonarTokenSecret)
       workspaces:
         - name: source
           workspace: shared-data

--- a/tekton/base/tasks/sonar-scanner.yaml
+++ b/tekton/base/tasks/sonar-scanner.yaml
@@ -86,5 +86,5 @@ spec:
         - name: SONAR_TOKEN
           valueFrom:
             secretKeyRef:
-              name: $(params.sonarTokenSecret)
+              name: $(params.SONAR_TOKEN_SECRET)
               key: secretToken

--- a/tekton/base/tasks/sonar-scanner.yaml
+++ b/tekton/base/tasks/sonar-scanner.yaml
@@ -30,6 +30,9 @@ spec:
     - name: SONAR_PROJECT_KEY
       description: Project's unique key
       default: "tekton"
+    - name: SONAR_TOKEN_SECRET
+      description: The name of the secret containing the Sonar token.
+      default: tkn-sonar-token
   steps:
     - name: sonar-properties-create
       image: registry.access.redhat.com/ubi8/ubi-minimal:8.2
@@ -83,5 +86,5 @@ spec:
         - name: SONAR_TOKEN
           valueFrom:
             secretKeyRef:
-              name: tkn-sonar-secret
+              name: $(params.sonarTokenSecret)
               key: secretToken

--- a/tekton/overlays/creds/kustomization.yaml
+++ b/tekton/overlays/creds/kustomization.yaml
@@ -18,7 +18,7 @@ secretGenerator:
     type: Opaque
     literals:
       - secretToken=
-  - name: sonar-token
+  - name: tkn-sonar-token
     type: Opaque
     literals:
       - secretToken=


### PR DESCRIPTION
### **sonar-scan**

*Scans a given repository against a provided SonarCloud/SonarQube project. [SonarCloud](https://sonarcloud.io/)*

Requires a secret within the task named `tkn-sonar-secret`. This is used to authenticate to SonarCloud or SonarQube.

For scans with SonarCloud, create a `sonar-project.properties` file at the root of the repository that is referenced in the `repoUrl` parameter.

```conf
# sonar-project.properties
sonar.organization=ci-testing
sonar.projectKey=tekton
sonar.host.url=https://sonarcloud.io
```

- **sonarHostUrl**: The SonarQube/SonarCloud instance.  
- **sonarProject**: The project to run the scan against.  
- **sonarTokenSecret**: The authentication token for SonarQube/SonarCloud.

```yaml
cat <<EOF | kubectl create -f -
apiVersion: tekton.dev/v1beta1
kind: PipelineRun
metadata:
  generateName: sonar-scanner-run-
spec:
  pipelineRef:
    name: p-sonar
  params:
  - name: sonarHostUrl
    value: https://sonarcloud.io
  - name: sonarProject
    value: tekton
  - name: sonarTokenSecret
    value: tkn-sonar-token
  - name: repoUrl
    value: git@github.com:gregnrobinson/gregrobinson-ca-k8s.git
  - name: branchName
    value: main
  workspaces:
  - name: shared-data
    volumeClaimTemplate:
      spec:
        accessModes:
        - ReadWriteOnce
        resources:
          requests:
            storage: 1Gi
  - name: ssh-creds
    secret:
      secretName: tkn-ssh-credentials
  - name: sonar-settings
    emptyDir: {}
EOF
```